### PR TITLE
[WIP] Add ability to create an expense

### DIFF
--- a/client/src/api/GroupAPI.js
+++ b/client/src/api/GroupAPI.js
@@ -1,11 +1,21 @@
 /**
  * Creates an expense that is associated to borrowers who owe money to the
  * lender.
+ *
+ * @param {Date} creationDatetime The date and time when the expense was
+ *     created.
+ * @param {String} author The user who created the expense.
+ * @param {String} title The title stating what the expense was.
+ * @param {String} description The description of the expense.
+ * @param {Number} amount The amount of the expense in GBP.
+ * @param {String} lender The user who lent money for the expense.
+ * @param {String[]} borrowers The users who owe money for the expense.
  */
 function addGroupExpense(
   creationDatetime,
   author,
   title,
+  description,
   amount,
   lender,
   borrowers
@@ -15,6 +25,7 @@ function addGroupExpense(
       creationDatetime,
       author,
       title,
+      description,
       amount,
       lender,
       borrowers,


### PR DESCRIPTION
## Changes
- Added a function, `addGroupExpense`, to create an expense that is associated to borrowers who owe money to a lender.

## Related Issues
This fixes [issue #4](https://github.com/IsaacCheng9/fairsplit/issues/4).