### PR TITLE
Fix broken GitHub Action for Prettier

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Format with Prettier
-        uses: creyD/prettier_action@v4.2
+        uses: creyD/prettier_action@v4.3
         with:
           commit_message: Format code with Prettier
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can
       # access it.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Format with Prettier
         uses: creyD/prettier_action@v4.2


### PR DESCRIPTION
## Summary
- Recent changes to `prettier_action` have caused the action to break, stating that prettier can't be found (see [issue here](https://github.com/creyD/prettier_action/issues/115)).
- Updated the version of `prettier_action` from `4.2` to `4.3` to fix this.