### PR TITLE
fix(server): Make ledger writes atomic

### DIFF
--- a/server/controllers/debt_controller.js
+++ b/server/controllers/debt_controller.js
@@ -1,6 +1,5 @@
 const debtModel = require("../models/debt");
 const optimisedDebtModel = require("../models/optimised_debt");
-const userDebtModel = require("../models/user_debt");
 const helpers = require("./helpers/index");
 
 // Get a list of all debts.
@@ -26,115 +25,126 @@ exports.getDebtBetweenUsers = async (request, response) => {
 
 // Add a debt between two users.
 exports.addDebt = async (request, response) => {
-  let message = await helpers.processNewDebt(
-    request.body.from,
-    request.body.to,
-    request.body.amount,
-  );
+  const message = await helpers.withTransaction(async (session) => {
+    const message = await helpers.processNewDebt(
+      request.body.from,
+      request.body.to,
+      request.body.amount,
+      session,
+    );
+    await helpers.simplifyDebts(session);
+    return message;
+  });
+
   response.status(201).send(message);
 };
 
 // Settle a debt by ID.
 exports.settleDebt = async (request, response) => {
-  // Search for a debt by swapping the from and to fields, as a settlement is
-  // effectively a reverse debt.
-  const existingDebt = await debtModel.findOne({
-    from: request.body.to,
-    to: request.body.from,
-  });
-
-  if (request.body.amount <= 0) {
-    response.status(400).send("Amount must be greater than £0.");
-  } else if (existingDebt && existingDebt.amount > request.body.amount) {
-    // If the existing debt is greater than the amount to be settled, then
-    // reduce the debt.
-    await debtModel.findOneAndUpdate(
-      {
+  const result = await helpers.withTransaction(async (session) => {
+    // Search for a debt by swapping the from and to fields, as a settlement is
+    // effectively a reverse debt.
+    const existingDebt = await debtModel
+      .findOne({
         from: request.body.to,
         to: request.body.from,
-      },
-      {
-        $inc: { amount: -request.body.amount },
-      },
-    );
-    // The borrower owes less, so the lender owes more.
-    await userDebtModel.findOneAndUpdate(
-      { username: request.body.from },
-      { $inc: { netDebt: -request.body.amount } },
-    );
-    await userDebtModel.findOneAndUpdate(
-      { username: request.body.to },
-      { $inc: { netDebt: request.body.amount } },
-    );
-    // Recalculate debts to minimise the number of transactions, as this
-    // settlement may have changed the optimal strategy.
-    await helpers.simplifyDebts();
-    response.send(
-      `Debt from '${request.body.from}' to '${request.body.to}' partially\
-        settled and reduced successfully.`,
-    );
-  } else if (existingDebt && existingDebt.amount === request.body.amount) {
+      })
+      .session(session);
+
+    if (!existingDebt || existingDebt.amount < request.body.amount) {
+      return {
+        status: 400,
+        message: "You cannot settle more than the amount of the debt.",
+      };
+    }
+
     // If the existing debt is equal to the amount to be settled, then delete
-    // the debt.
-    await debtModel.findOneAndDelete({
-      from: request.body.to,
-      to: request.body.from,
-    });
+    // the debt. Otherwise, reduce it.
+    if (existingDebt.amount === request.body.amount) {
+      await debtModel
+        .findOneAndDelete({
+          from: request.body.to,
+          to: request.body.from,
+        })
+        .session(session);
+    } else {
+      await debtModel.findOneAndUpdate(
+        {
+          from: request.body.to,
+          to: request.body.from,
+        },
+        {
+          $inc: { amount: -request.body.amount },
+        },
+        { session },
+      );
+    }
+
     // The borrower owes less, so the lender owes more.
-    await userDebtModel.findOneAndUpdate(
-      { username: request.body.from },
-      { $inc: { netDebt: -request.body.amount } },
+    await helpers.adjustUserDebt(
+      request.body.from,
+      -request.body.amount,
+      session,
     );
-    await userDebtModel.findOneAndUpdate(
-      { username: request.body.to },
-      { $inc: { netDebt: request.body.amount } },
-    );
+    await helpers.adjustUserDebt(request.body.to, request.body.amount, session);
+
     // Recalculate debts to minimise the number of transactions, as this
     // settlement may have changed the optimal strategy.
-    await helpers.simplifyDebts();
-    response.send(
-      `Debt from '${request.body.from}' to '${request.body.to}' fully\
-        settled and deleted successfully.`,
-    );
-  } else {
-    response
-      .status(400)
-      .send("You cannot settle more than the amount of the debt.");
-  }
+    await helpers.simplifyDebts(session);
+
+    const settlementType =
+      existingDebt.amount === request.body.amount ? "fully" : "partially";
+    const settlementAction =
+      existingDebt.amount === request.body.amount ? "deleted" : "reduced";
+
+    return {
+      status: 200,
+      message: `Debt from '${request.body.from}' to '${request.body.to}' ${settlementType}\
+        settled and ${settlementAction} successfully.`,
+    };
+  });
+
+  response.status(result.status).send(result.message);
 };
 
 // Delete a debt between a lender and borrower.
 exports.deleteDebtBetweenUsers = async (request, response) => {
-  // Find the debt first so we know the amount to adjust balances.
-  const debt = await debtModel.findOne({
-    from: request.params.from,
-    to: request.params.to,
+  const result = await helpers.withTransaction(async (session) => {
+    // Find the debt first so we know the amount to adjust balances.
+    const debt = await debtModel
+      .findOne({
+        from: request.params.from,
+        to: request.params.to,
+      })
+      .session(session);
+
+    if (!debt) {
+      return {
+        status: 404,
+        message: "Debt not found.",
+      };
+    }
+
+    // Delete the debt.
+    await debtModel
+      .deleteOne({
+        from: request.params.from,
+        to: request.params.to,
+      })
+      .session(session);
+
+    // Update userDebt balances: the borrower owes less, the lender is owed less.
+    await helpers.adjustUserDebt(request.params.from, -debt.amount, session);
+    await helpers.adjustUserDebt(request.params.to, debt.amount, session);
+
+    // Recalculate optimised debts.
+    await helpers.simplifyDebts(session);
+    return {
+      status: 200,
+      message: `Debt from '${request.params.from}' to '${request.params.to}' deleted\
+        successfully.`,
+    };
   });
 
-  if (!debt) {
-    return response.status(404).send("Debt not found.");
-  }
-
-  // Delete the debt.
-  await debtModel.deleteOne({
-    from: request.params.from,
-    to: request.params.to,
-  });
-
-  // Update userDebt balances: the borrower owes less, the lender is owed less.
-  await userDebtModel.findOneAndUpdate(
-    { username: request.params.from },
-    { $inc: { netDebt: -debt.amount } },
-  );
-  await userDebtModel.findOneAndUpdate(
-    { username: request.params.to },
-    { $inc: { netDebt: debt.amount } },
-  );
-
-  // Recalculate optimised debts.
-  await helpers.simplifyDebts();
-  response.send(
-    `Debt from '${request.params.from}' to '${request.params.to}' deleted\
-      successfully.`,
-  );
+  response.status(result.status).send(result.message);
 };

--- a/server/controllers/expense_controller.js
+++ b/server/controllers/expense_controller.js
@@ -3,45 +3,39 @@ const expenseModel = require("../models/expense");
 
 // Add an expense and create the related debts between lender and borrowers.
 exports.addExpense = async (request, response) => {
-  // Check that the sum of amounts owed matches the total expense amount.
-  let currentSum = 0;
-  for (const borrower of request.body.borrowers) {
-    if (borrower[1] <= 0) {
-      return response.status(400).json({
-        error: "The amount owed must be a positive number.",
-      });
-    } else {
-      currentSum += borrower[1];
-    }
-  }
-  if (currentSum !== request.body.amount) {
-    return response.status(400).json({
-      error: "The sum of amounts owed must equal the total expense amount.",
+  const expense = await helpers.withTransaction(async (session) => {
+    // Keep a record of the expense for the history.
+    const expense = new expenseModel({
+      title: request.body.title,
+      author: request.body.author,
+      lender: request.body.lender,
+      borrowers: request.body.borrowers,
+      amount: request.body.amount,
     });
-  }
 
-  // Keep a record of the expense for the history.
-  const expense = await expenseModel.create({
-    title: request.body.title,
-    author: request.body.author,
-    lender: request.body.lender,
-    borrowers: request.body.borrowers,
-    amount: request.body.amount,
+    await expense.save({ session });
+
+    // Loop through each borrower and create/update debts accordingly.
+    for (const borrowerInfo of request.body.borrowers) {
+      const borrower = borrowerInfo[0];
+      // The amount they owe must be handled before this to account for different
+      // methods of splitting the expense (e.g. specific amounts, by percentage,
+      // etc.).
+      const owedAmount = borrowerInfo[1];
+      await helpers.processNewDebt(
+        borrower,
+        request.body.lender,
+        owedAmount,
+        session,
+      );
+    }
+
+    // Recalculate debts to minimise the number of transactions, as this
+    // settlement may have changed the optimal strategy.
+    await helpers.simplifyDebts(session);
+    return expense;
   });
 
-  // Loop through each borrower and create/update debts accordingly.
-  for (const borrowerInfo of request.body.borrowers) {
-    const borrower = borrowerInfo[0];
-    // The amount they owe must be handled before this to account for different
-    // methods of splitting the expense (e.g. specific amounts, by percentage,
-    // etc.).
-    const owedAmount = borrowerInfo[1];
-    await helpers.processNewDebt(borrower, request.body.lender, owedAmount);
-  }
-
-  // Recalculate debts to minimise the number of transactions, as this
-  // settlement may have changed the optimal strategy.
-  await helpers.simplifyDebts();
   response.status(201).json(expense);
 };
 

--- a/server/controllers/helpers/index.js
+++ b/server/controllers/helpers/index.js
@@ -1,26 +1,82 @@
+const mongoose = require("mongoose");
 const Heap = require("heap");
 const debtModel = require("../../models/debt");
 const userDebtModel = require("../../models/user_debt");
 const optimisedDebtModel = require("../../models/optimised_debt");
 
-// Add a debt, including processing of the reverse debt.
-exports.processNewDebt = async function (from, to, amount) {
-  // The borrower owes more, so the lender owes less.
+const MAX_TRANSACTION_ATTEMPTS = 5;
+
+function getSessionOptions(session) {
+  return session ? { session } : {};
+}
+
+function withSession(query, session) {
+  return session ? query.session(session) : query;
+}
+
+function isTransientTransactionError(error) {
+  return (
+    typeof error.hasErrorLabel === "function" &&
+    error.hasErrorLabel("TransientTransactionError")
+  );
+}
+
+exports.withTransaction = async function (work) {
+  for (let attempt = 1; attempt <= MAX_TRANSACTION_ATTEMPTS; attempt++) {
+    try {
+      return await mongoose.connection.transaction(work);
+    } catch (error) {
+      if (
+        attempt === MAX_TRANSACTION_ATTEMPTS ||
+        !isTransientTransactionError(error)
+      ) {
+        throw error;
+      }
+    }
+  }
+};
+
+exports.adjustUserDebt = async function (username, amount, session) {
   await userDebtModel.findOneAndUpdate(
-    { username: from },
+    { username },
     { $inc: { netDebt: amount } },
+    {
+      new: true,
+      runValidators: true,
+      upsert: true,
+      ...getSessionOptions(session),
+    },
   );
-  await userDebtModel.findOneAndUpdate(
-    { username: to },
-    { $inc: { netDebt: -amount } },
+};
+
+async function incrementDebt(from, to, amount, session) {
+  await debtModel.findOneAndUpdate(
+    { from, to },
+    { $inc: { amount } },
+    {
+      new: true,
+      runValidators: true,
+      upsert: true,
+      ...getSessionOptions(session),
+    },
   );
+}
+
+// Add a debt, including processing of the reverse debt.
+exports.processNewDebt = async function (from, to, amount, session = null) {
+  // The borrower owes more, so the lender owes less.
+  await exports.adjustUserDebt(from, amount, session);
+  await exports.adjustUserDebt(to, -amount, session);
 
   // Check whether the debt exists the other way around, as this new debt may
   // cancel out the reverse debt.
-  const reverseDebt = await debtModel.findOne({
-    from: to,
-    to: from,
-  });
+  const reverseDebt = await withSession(
+    debtModel.findOne({
+      from: to,
+      to: from,
+    }),
+    session,
+  );
   // Keep track of the debt amount to add, as this may change if there is a
   // reverse debt to be settled.
   let debtAmount = amount;
@@ -35,16 +91,20 @@ exports.processNewDebt = async function (from, to, amount) {
       {
         $inc: { amount: -amount },
       },
+      getSessionOptions(session),
     );
     debtAmount = 0;
   } else if (reverseDebt && reverseDebt.amount <= amount) {
     // If the reverse debt is less than or equal to the new debt, then delete
     // the reverse debt and update the new debt amount.
     debtAmount -= reverseDebt.amount;
-    await debtModel.findOneAndDelete({
-      from: to,
-      to: from,
-    });
+    await withSession(
+      debtModel.findOneAndDelete({
+        from: to,
+        to: from,
+      }),
+      session,
+    );
   }
 
   // If the reverse debt has cancelled out the new debt, then don't add a new
@@ -53,40 +113,14 @@ exports.processNewDebt = async function (from, to, amount) {
     return `The new debt was used to cancel out a reverse debt, so a new debt\
     from '${from}' to '${to}' was not added.`;
   } else {
-    // Check whether the debt exists between two users so that we can either
-    // create a new debt, or update an existing debt.
-    const debtExists = await debtModel.exists({
-      from: from,
-      to: to,
-    });
-
-    if (debtExists) {
-      // Update the debt between the lender and borrower.
-      await debtModel.findOneAndUpdate(
-        {
-          from: from,
-          to: to,
-        },
-        {
-          $inc: { amount: debtAmount },
-        },
-      );
-      return `Debt from '${from}' to '${to}' was updated successfully.`;
-    } else {
-      // Create a new debt between the lender and borrower.
-      await debtModel.create({
-        from: from,
-        to: to,
-        amount: debtAmount,
-      });
-      return `Debt from '${from}' to '${to}' was created successfully.`;
-    }
+    await incrementDebt(from, to, debtAmount, session);
+    return `Debt from '${from}' to '${to}' was updated successfully.`;
   }
 };
 
 // Simplify debts to minimise the total number of transactions required to get
 // to a balanced state using a greedy heuristic algorithm.
-exports.simplifyDebts = async function () {
+exports.simplifyDebts = async function (session = null) {
   // Create min-heaps for debt and credit so we can automatically find the
   // smallest amounts and who they belong to in O(n log n) time.
   let minHeapDebt = new Heap(function (a, b) {
@@ -97,7 +131,7 @@ exports.simplifyDebts = async function () {
   });
 
   // Add users to a min-heap for debt and credit.
-  for await (const userDebt of userDebtModel.find({})) {
+  for await (const userDebt of withSession(userDebtModel.find({}), session)) {
     if (userDebt.netDebt > 0) {
       minHeapDebt.push({
         username: userDebt.username,
@@ -111,8 +145,8 @@ exports.simplifyDebts = async function () {
     }
   }
 
-  // Create a new set of optimised debts to store the simplified debts.
-  await optimisedDebtModel.deleteMany({});
+  const optimisedDebts = [];
+
   // Create transactions until the min-heaps are empty to reach a zero-state.
   while (!minHeapDebt.empty() && !minHeapCredit.empty()) {
     const smallestDebt = minHeapDebt.pop();
@@ -122,7 +156,7 @@ exports.simplifyDebts = async function () {
       smallestDebt.amount,
       smallestCredit.amount,
     );
-    await optimisedDebtModel.create({
+    optimisedDebts.push({
       from: smallestDebt.username,
       to: smallestCredit.username,
       amount: transactionAmount,
@@ -143,4 +177,28 @@ exports.simplifyDebts = async function () {
       });
     }
   }
+
+  const operations = [
+    {
+      deleteMany: {
+        filter: {},
+      },
+    },
+    ...optimisedDebts.map((optimisedDebt) => {
+      return {
+        updateOne: {
+          filter: {
+            from: optimisedDebt.from,
+            to: optimisedDebt.to,
+          },
+          update: {
+            $set: optimisedDebt,
+          },
+          upsert: true,
+        },
+      };
+    }),
+  ];
+
+  await optimisedDebtModel.bulkWrite(operations, getSessionOptions(session));
 };

--- a/server/jest-mongodb-config.js
+++ b/server/jest-mongodb-config.js
@@ -8,5 +8,9 @@ module.exports = {
     instance: {
       dbName: "fairsplit-test",
     },
+    replSet: {
+      count: 1,
+      storageEngine: "wiredTiger",
+    },
   },
 };

--- a/server/models/debt.js
+++ b/server/models/debt.js
@@ -20,4 +20,6 @@ const debtSchema = new mongoose.Schema({
   },
 });
 
+debtSchema.index({ from: 1, to: 1 }, { unique: true });
+
 module.exports = mongoose.model("debt", debtSchema);

--- a/server/models/optimised_debt.js
+++ b/server/models/optimised_debt.js
@@ -22,4 +22,6 @@ const optimisedDebtSchema = new mongoose.Schema({
   },
 });
 
+optimisedDebtSchema.index({ from: 1, to: 1 }, { unique: true });
+
 module.exports = mongoose.model("optimised_debt", optimisedDebtSchema);

--- a/server/routes/debts.test.js
+++ b/server/routes/debts.test.js
@@ -3,6 +3,7 @@ const supertest = require("supertest");
 const mongoose = require("mongoose");
 
 const debtsRouter = require("../routes/debts.js");
+const helpers = require("../controllers/helpers");
 const debtModel = require("../models/debt");
 const optimisedDebtModel = require("../models/optimised_debt");
 const userDebtModel = require("../models/user_debt");
@@ -18,6 +19,9 @@ describe("Test for debt routes", () => {
     connection = await mongoose.connect(globalThis.__MONGO_URI__, {
       dbName: "fairsplit-debts-test",
     });
+    await debtModel.syncIndexes();
+    await optimisedDebtModel.syncIndexes();
+    await userDebtModel.syncIndexes();
   });
 
   afterEach(async () => {
@@ -85,6 +89,48 @@ describe("Test for debt routes", () => {
       .expect((response) => {
         expect(response.body.error).toMatch(/integer number of pence/);
       });
+  });
+
+  test("POST /debts/add coalesces concurrent matching debts", async () => {
+    const server = supertest(app);
+    await userDebtModel.create({ username: "alice", netDebt: 0 });
+    await userDebtModel.create({ username: "bob", netDebt: 0 });
+
+    await Promise.all(
+      Array.from({ length: 8 }, () => {
+        return server
+          .post("/debts/add")
+          .send({ from: "alice", to: "bob", amount: 1 })
+          .expect(201);
+      }),
+    );
+
+    const debts = await debtModel.find({ from: "alice", to: "bob" });
+    expect(debts).toHaveLength(1);
+    expect(debts[0].amount).toBe(8);
+
+    const aliceDebt = await userDebtModel.findOne({ username: "alice" });
+    const bobDebt = await userDebtModel.findOne({ username: "bob" });
+    expect(aliceDebt.netDebt).toBe(8);
+    expect(bobDebt.netDebt).toBe(-8);
+  });
+
+  test("simplifyDebts coalesces concurrent optimised debt rebuilds", async () => {
+    await userDebtModel.create({ username: "alice", netDebt: 10 });
+    await userDebtModel.create({ username: "bob", netDebt: -10 });
+
+    await Promise.all(
+      Array.from({ length: 8 }, () => {
+        return helpers.simplifyDebts();
+      }),
+    );
+
+    const optimisedDebts = await optimisedDebtModel.find({
+      from: "alice",
+      to: "bob",
+    });
+    expect(optimisedDebts).toHaveLength(1);
+    expect(optimisedDebts[0].amount).toBe(10);
   });
 
   // Check whether we can get the new debt between two users.

--- a/server/routes/expenses.test.js
+++ b/server/routes/expenses.test.js
@@ -3,6 +3,7 @@ const supertest = require("supertest");
 const mongoose = require("mongoose");
 
 const expensesRouter = require("../routes/expenses.js");
+const helpers = require("../controllers/helpers");
 const debtModel = require("../models/debt");
 const expenseModel = require("../models/expense");
 const optimisedDebtModel = require("../models/optimised_debt");
@@ -19,6 +20,9 @@ describe("Test for expense routes", () => {
     connection = await mongoose.connect(globalThis.__MONGO_URI__, {
       dbName: "fairsplit-expenses-test",
     });
+    await debtModel.syncIndexes();
+    await optimisedDebtModel.syncIndexes();
+    await userDebtModel.syncIndexes();
   });
 
   afterEach(async () => {
@@ -129,6 +133,33 @@ describe("Test for expense routes", () => {
       .expect((response) => {
         expect(response.body.error).toMatch(/Borrower 1/);
       });
+  });
+
+  test("POST /expenses rolls back history when debt processing fails", async () => {
+    const processNewDebt = jest
+      .spyOn(helpers, "processNewDebt")
+      .mockRejectedValueOnce(new Error("Forced ledger failure."));
+    const server = supertest(app);
+
+    try {
+      await server
+        .post("/expenses")
+        .send({
+          title: "rollbackexpense",
+          author: "testuser123",
+          lender: "testuser123",
+          borrowers: [["testuser456", 100]],
+          amount: 100,
+        })
+        .expect(500);
+
+      await expect(
+        expenseModel.countDocuments({ title: "rollbackexpense" }),
+      ).resolves.toBe(0);
+      await expect(debtModel.countDocuments({})).resolves.toBe(0);
+    } finally {
+      processNewDebt.mockRestore();
+    }
   });
 
   // Check whether we can add a settlement between two users as an expense.


### PR DESCRIPTION
# Summary
- Wrapped ledger mutations in MongoDB transactions
  - Preserved debt, user balance, optimised ledger, and expense history consistency when one step failed
- Replaced debt and optimised debt creation paths with atomic upserts
  - Added uniqueness constraints on user pairs so concurrent writes coalesced instead of creating duplicate ledger rows
- Updated the in-memory MongoDB test server to run as a replica set
  - Exercised the same transaction path that production MongoDB expects
- Added regression coverage for concurrent debt writes, concurrent optimised rebuilds, and expense rollback on ledger failure

## Rationale
- The old flow wrote history and ledger documents in separate operations
  - A mid-request failure could leave an expense visible in history without matching debt rows, or duplicate raw/optimised debt rows under concurrent requests
- Transaction retries were limited to transient transaction-body failures
  - Retrying after an ambiguous commit result can double-apply non-idempotent work if the commit already succeeded