### PR TITLE
fix(server): Settle debt history atomically

### DIFF
--- a/client/src/components/app.jsx
+++ b/client/src/components/app.jsx
@@ -147,42 +147,22 @@ function App() {
   }
 
   // Update group state after a user settles up
-  async function updateDebt(settleObject) {
+  async function updateDebt(settlement) {
+    const settledUsername = settlement.borrowers[0][0];
+    const settledAmount = settlement.amount;
+    const settledDebt = group.usersMinusActive.debts[settledUsername];
+
     // Calculate outstanding balance
-    group.usersMinusActive.debts[settleObject.from].amount -=
-      settleObject.amount;
-    group.usersMinusActive.outstandingBalance -= settleObject.amount;
-
-    // Create settlement object with the same structure as an expense
-    let settlement = {
-      title: "SETTLEMENT",
-      lender: settleObject.to,
-      amount: settleObject.amount,
-      author: settleObject.to,
-      borrowers: [settleObject.from, settleObject.amount],
-    };
-
-    // Add settlement as expense for now
-    let validExpense = await fetch(
-      "http://localhost:3000/expenses/settlement",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(settlement),
+    if (settledDebt) {
+      settledDebt.amount -= settledAmount;
+      if (settledDebt.amount <= 0) {
+        delete group.usersMinusActive.debts[settledUsername];
       }
-    );
-
-    let response = await validExpense.json();
-
-    if (validExpense.ok) {
-      // Add settlement to array of expenses
-      group.expenses.unshift(response);
-    } else {
-      // Display error message
-      console.error(response.error);
     }
+    group.usersMinusActive.outstandingBalance -= settledAmount;
+
+    // Add settlement to array of expenses
+    group.expenses.unshift(settlement);
 
     setGroup({
       ...group,

--- a/client/src/components/group_users.jsx
+++ b/client/src/components/group_users.jsx
@@ -42,7 +42,7 @@ function GroupUsers(props) {
     let settleObject = {
       from: userSelectRef.current.value,
       to: props.group.activeUser,
-      amount: settleAmount * 100,
+      amount: Math.round(Number(settleAmount) * 100),
     };
 
     // Disable and clear form
@@ -58,9 +58,18 @@ function GroupUsers(props) {
       body: JSON.stringify(settleObject),
     });
 
+    const contentType = settleDebtResponse.headers.get("content-type") || "";
+    const responseBody = contentType.includes("application/json")
+      ? await settleDebtResponse.json()
+      : await settleDebtResponse.text();
+    const responseMessage =
+      typeof responseBody === "string"
+        ? responseBody
+        : responseBody.message || responseBody.error;
+
     // Reset styling and set message to response of API call
     setMsgClasses("group-members-msg");
-    setResponseMsg(await settleDebtResponse.text());
+    setResponseMsg(responseMessage);
 
     // Add class with 0 opacity to trigger fade transition after 1.5s of showing message
     setTimeout(() => {
@@ -69,7 +78,7 @@ function GroupUsers(props) {
 
     // If successful update debts
     if (settleDebtResponse.status === 200) {
-      props.onClick(settleObject);
+      props.onClick(responseBody.settlement);
     }
   }
 

--- a/server/controllers/debt_controller.js
+++ b/server/controllers/debt_controller.js
@@ -1,4 +1,5 @@
 const debtModel = require("../models/debt");
+const expenseModel = require("../models/expense");
 const optimisedDebtModel = require("../models/optimised_debt");
 const helpers = require("./helpers/index");
 
@@ -80,17 +81,30 @@ exports.settleDebt = async (request, response) => {
       );
     }
 
-    // The borrower owes less, so the lender owes more.
+    // The borrower owes less, and the lender is owed less.
     await helpers.adjustUserDebt(
       request.body.from,
+      request.body.amount,
+      session,
+    );
+    await helpers.adjustUserDebt(
+      request.body.to,
       -request.body.amount,
       session,
     );
-    await helpers.adjustUserDebt(request.body.to, request.body.amount, session);
 
     // Recalculate debts to minimise the number of transactions, as this
     // settlement may have changed the optimal strategy.
     await helpers.simplifyDebts(session);
+
+    const settlement = new expenseModel({
+      title: "SETTLEMENT",
+      author: request.body.to,
+      lender: request.body.to,
+      borrowers: [[request.body.from, request.body.amount]],
+      amount: request.body.amount,
+    });
+    await settlement.save({ session });
 
     const settlementType =
       existingDebt.amount === request.body.amount ? "fully" : "partially";
@@ -101,10 +115,18 @@ exports.settleDebt = async (request, response) => {
       status: 200,
       message: `Debt from '${request.body.from}' to '${request.body.to}' ${settlementType}\
         settled and ${settlementAction} successfully.`,
+      settlement,
     };
   });
 
-  response.status(result.status).send(result.message);
+  if (result.status !== 200) {
+    return response.status(result.status).send(result.message);
+  }
+
+  response.status(result.status).json({
+    message: result.message,
+    settlement: result.settlement,
+  });
 };
 
 // Delete a debt between a lender and borrower.

--- a/server/controllers/expense_controller.js
+++ b/server/controllers/expense_controller.js
@@ -44,16 +44,3 @@ exports.getExpenses = async (_, response) => {
   const expenses = await expenseModel.find({});
   response.json(expenses);
 };
-
-// Temporary controller to add settlement as expense.
-exports.addSettlement = async (request, response) => {
-  // Keep a record of the settlement for the history.
-  const settlement = await expenseModel.create({
-    title: request.body.title,
-    author: request.body.author,
-    lender: request.body.lender,
-    borrowers: request.body.borrowers,
-    amount: request.body.amount,
-  });
-  response.status(201).json(settlement);
-};

--- a/server/routes/debts.test.js
+++ b/server/routes/debts.test.js
@@ -5,6 +5,7 @@ const mongoose = require("mongoose");
 const debtsRouter = require("../routes/debts.js");
 const helpers = require("../controllers/helpers");
 const debtModel = require("../models/debt");
+const expenseModel = require("../models/expense");
 const optimisedDebtModel = require("../models/optimised_debt");
 const userDebtModel = require("../models/user_debt");
 
@@ -26,6 +27,7 @@ describe("Test for debt routes", () => {
 
   afterEach(async () => {
     await debtModel.deleteMany({});
+    await expenseModel.deleteMany({});
     await optimisedDebtModel.deleteMany({});
     await userDebtModel.deleteMany({});
   });
@@ -147,9 +149,11 @@ describe("Test for debt routes", () => {
       to: "testuser456",
       amount: 100,
     });
+    await userDebtModel.create({ username: "testuser123", netDebt: 100 });
+    await userDebtModel.create({ username: "testuser456", netDebt: -100 });
 
     const server = supertest(app);
-    await server
+    const response = await server
       .post("/debts/settle")
       .send({
         from: "testuser456",
@@ -157,6 +161,15 @@ describe("Test for debt routes", () => {
         amount: 50,
       })
       .expect(200);
+
+    expect(response.body.message).toMatch(/partially/);
+    expect(response.body.settlement).toMatchObject({
+      title: "SETTLEMENT",
+      author: "testuser123",
+      lender: "testuser123",
+      borrowers: [["testuser456", 50]],
+      amount: 50,
+    });
 
     // Check whether the debt was successfully reduced by 50.
     await debtModel
@@ -167,6 +180,54 @@ describe("Test for debt routes", () => {
       .then((debt) => {
         expect(debt.amount).toBe(50);
       });
+
+    const borrowerDebt = await userDebtModel.findOne({
+      username: "testuser123",
+    });
+    const lenderDebt = await userDebtModel.findOne({
+      username: "testuser456",
+    });
+    expect(borrowerDebt.netDebt).toBe(50);
+    expect(lenderDebt.netDebt).toBe(-50);
+
+    const settlement = await expenseModel.findOne({ title: "SETTLEMENT" });
+    expect(settlement.borrowers).toEqual([["testuser456", 50]]);
+  });
+
+  test("POST /debts/settle rolls back debt changes when history fails", async () => {
+    await debtModel.create({
+      from: "alice",
+      to: "bob",
+      amount: 100,
+    });
+    await userDebtModel.create({ username: "alice", netDebt: 100 });
+    await userDebtModel.create({ username: "bob", netDebt: -100 });
+    const saveSettlement = jest
+      .spyOn(expenseModel.prototype, "save")
+      .mockRejectedValueOnce(new Error("Forced settlement history failure."));
+
+    const server = supertest(app);
+    try {
+      await server
+        .post("/debts/settle")
+        .send({
+          from: "bob",
+          to: "alice",
+          amount: 50,
+        })
+        .expect(500);
+
+      const debt = await debtModel.findOne({ from: "alice", to: "bob" });
+      const borrowerDebt = await userDebtModel.findOne({ username: "alice" });
+      const lenderDebt = await userDebtModel.findOne({ username: "bob" });
+
+      expect(debt.amount).toBe(100);
+      expect(borrowerDebt.netDebt).toBe(100);
+      expect(lenderDebt.netDebt).toBe(-100);
+      await expect(expenseModel.countDocuments({})).resolves.toBe(0);
+    } finally {
+      saveSettlement.mockRestore();
+    }
   });
 
   // Check whether we can delete the debt we created between two users.

--- a/server/routes/expenses.js
+++ b/server/routes/expenses.js
@@ -14,13 +14,6 @@ app.post(
   asyncHandler(expenseController.addExpense),
 );
 
-// Temporary route for adding settlement as expense.
-app.post(
-  "/expenses/settlement",
-  validateExpense,
-  asyncHandler(expenseController.addSettlement),
-);
-
 app.use(errorHandler);
 
 module.exports = app;

--- a/server/routes/expenses.test.js
+++ b/server/routes/expenses.test.js
@@ -161,19 +161,4 @@ describe("Test for expense routes", () => {
       processNewDebt.mockRestore();
     }
   });
-
-  // Check whether we can add a settlement between two users as an expense.
-  test("POST /expenses/settlement", async () => {
-    const server = supertest(app);
-    await server
-      .post("/expenses/settlement")
-      .send({
-        title: "SETTLEMENT",
-        author: "testuser456",
-        lender: "testuser456",
-        borrowers: [["testuser123", 100]],
-        amount: 100,
-      })
-      .expect(201);
-  });
 });


### PR DESCRIPTION
# Summary
- Wrapped settlement history persistence into the existing debt settlement transaction
  - Kept the debt mutation, user balance updates, optimised debt recalculation, and history row as one committed unit
- Replaced the temporary settlement-history endpoint with a single server-led settlement response
  - Returned the persisted settlement to the client so history UI updates from the same API call
- Corrected settlement balance movement
  - Reduced both the borrower liability and lender receivable instead of increasing the outstanding ledger
- Added regression coverage for successful settlements and history-write rollback

## Rationale
- The previous two-step client flow could make debt state and expense history diverge
  - A successful `/debts/settle` followed by a failed `/expenses/settlement` left no historical record for a real settlement
- The old settlement history payload no longer matched the validated expense shape
  - Keeping history creation server-side avoids another client-side borrower tuple contract to maintain