### PR TITLE
fix(client): Handle empty groups and API paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,23 @@ jobs:
         working-directory: ./server
       - run: npm test
         working-directory: ./server
+
+  client-unit-tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+        working-directory: ./client
+      - run: CI=true npm test -- --watchAll=false
+        working-directory: ./client
+      - run: CI=true npm run build
+        working-directory: ./client

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17887,6 +17887,23 @@
         }
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,0 +1,5 @@
+const apiBaseUrl = process.env.REACT_APP_API_URL || "";
+
+export function apiPath(path) {
+  return `${apiBaseUrl}${path}`;
+}

--- a/client/src/components/add_user.jsx
+++ b/client/src/components/add_user.jsx
@@ -41,7 +41,7 @@ function AddUser(props) {
     } else {
       // Add classes that will animate the add user button
       setTransitionClass(
-        transitionClass + " add-user-plus-clicked x-rotate y-rotate"
+        transitionClass + " add-user-plus-clicked x-rotate y-rotate",
       );
 
       // Add class that will animate the cross SVG icon on the add user button
@@ -64,7 +64,18 @@ function AddUser(props) {
         className={inputClass}
         type="text"
       ></input>
-      <div className={transitionClass} onClick={addTransformClass}>
+      <div
+        aria-label="Add user"
+        className={transitionClass}
+        onClick={addTransformClass}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            addTransformClass();
+          }
+        }}
+        role="button"
+        tabIndex="0"
+      >
         <svg
           width="30"
           height="30"

--- a/client/src/components/app.jsx
+++ b/client/src/components/app.jsx
@@ -2,13 +2,13 @@ import React from "react";
 import { useEffect } from "react";
 import { useState } from "react";
 import "../styles/app.css";
+import { apiPath } from "../api";
+import AddUser from "./add_user";
 import GroupExpenses from "./group_expenses";
 import GroupUsers from "./group_users";
 import UserSwitching from "./user_switching";
 
 function App() {
-  const apiUrl = "http://localhost:3001";
-
   // Use this as global group
   let [group, setGroup] = useState({
     name: "Expenses",
@@ -23,10 +23,11 @@ function App() {
       outstandingBalance: 0,
     },
   });
+  let [isLoading, setIsLoading] = useState(true);
 
   // Gets all debt from db
   async function getAllDebt() {
-    let response = await fetch(`${apiUrl}/debts`);
+    let response = await fetch(apiPath("/debts"));
     let data = await response.json();
     return data;
   }
@@ -34,7 +35,7 @@ function App() {
   // Update Debts when expense is added
   async function updateDebts() {
     // Get Debts
-    let debtResponse = await fetch(`${apiUrl}/debts`);
+    let debtResponse = await fetch(apiPath("/debts"));
     const updatedDebt = await debtResponse.json();
     group.debts = updatedDebt;
     setActiveUserDebt();
@@ -62,14 +63,14 @@ function App() {
 
   // Gets all expenses from db
   async function getAllExpenses() {
-    const response = await fetch(`${apiUrl}/expenses`);
+    const response = await fetch(apiPath("/expenses"));
     const data = await response.json();
     return data;
   }
 
   // Gets all users from db
   async function getAllUsers() {
-    const response = await fetch(`${apiUrl}/users`);
+    const response = await fetch(apiPath("/users"));
     const data = await response.json();
     return data;
   }
@@ -91,20 +92,28 @@ function App() {
 
   // Updates global group with data from db
   async function loadDataIntoGroup() {
-    const debt = await getAllDebt();
-    const expenses = await getAllExpenses();
-    const users = await getAllUsers();
-    group = {
-      ...group,
-      expenses: expenses.reverse(),
-      users: users,
-      activeUser: users[0].username,
-      debts: debt,
-      usersMinusActive: {
-        users: users.slice(1),
-      },
-    };
-    setActiveUserDebt();
+    try {
+      const debt = await getAllDebt();
+      const expenses = await getAllExpenses();
+      const users = await getAllUsers();
+      const activeUser = users.length > 0 ? users[0].username : "";
+      group = {
+        ...group,
+        expenses: expenses.reverse(),
+        users: users,
+        activeUser: activeUser,
+        debts: debt,
+        usersMinusActive: {
+          ...group.usersMinusActive,
+          users: activeUser ? users.slice(1) : [],
+        },
+      };
+      setActiveUserDebt();
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   // Load all users and expenses into group
@@ -128,7 +137,7 @@ function App() {
 
   async function updateGroup(user) {
     // Add user to db
-    await fetch(`${apiUrl}/users`, {
+    const response = await fetch(apiPath("/users"), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -136,12 +145,25 @@ function App() {
       body: JSON.stringify(user),
     });
 
+    const createdUser = await response.json();
+    if (!response.ok) {
+      console.error(createdUser.error);
+      return;
+    }
+
+    const users = [...group.users, createdUser];
+    const activeUser = group.activeUser || createdUser.username;
+    const usersMinusActive = users.filter((user) => {
+      return user.username !== activeUser;
+    });
+
     setGroup({
       ...group,
-      users: [...group.users, user],
+      users: users,
+      activeUser: activeUser,
       usersMinusActive: {
         ...group.usersMinusActive,
-        users: [...group.usersMinusActive.users, user],
+        users: usersMinusActive,
       },
     });
   }
@@ -177,7 +199,7 @@ function App() {
     }
 
     // Get data from API
-    let response = await fetch(`${apiUrl}/${endpoint}`);
+    let response = await fetch(apiPath(`/${endpoint}`));
     const debt = await response.json();
 
     // Update global state
@@ -188,6 +210,44 @@ function App() {
 
     // Re-render debts
     setGroup({ ...group });
+  }
+
+  if (isLoading) {
+    return (
+      <div className="App">
+        <div className="header-container">
+          <h1 className="title">FairSplit</h1>
+        </div>
+      </div>
+    );
+  }
+
+  if (group.users.length === 0) {
+    return (
+      <div className="App">
+        <div className="header-container">
+          <h1 className="title">FairSplit</h1>
+        </div>
+        <div className="main-content-container">
+          <div className="group-members-container">
+            <h1 className="group-members-title">Group Members</h1>
+            <div className="users-container">
+              <AddUser
+                onClick={(username) => {
+                  updateGroup({
+                    username: username,
+                    firstName: "Cosmo",
+                    lastName: "Kramer",
+                    indebted: false,
+                    balance: 0,
+                  });
+                }}
+              ></AddUser>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/client/src/components/group_expenses.jsx
+++ b/client/src/components/group_expenses.jsx
@@ -1,5 +1,6 @@
 import React, { useState, createRef } from "react";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
+import { apiPath } from "../api";
 import "../styles/group_expenses.css";
 import Expense from "./expense";
 import AddExpense from "./add_expense";
@@ -17,7 +18,7 @@ function GroupExpenses(props) {
   // Add expense data to db
   async function addExpense(expense) {
     // Call route to add expense to db
-    let validExpense = await fetch("http://localhost:3000/expenses", {
+    let validExpense = await fetch(apiPath("/expenses"), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -64,12 +65,12 @@ function GroupExpenses(props) {
             ? "£" +
               String(
                 (props.group.usersMinusActive.outstandingBalance / 100).toFixed(
-                  2
-                )
+                  2,
+                ),
               ).substring(1)
             : "£" +
               (props.group.usersMinusActive.outstandingBalance / 100).toFixed(
-                2
+                2,
               )}
         </span>
       </h2>

--- a/client/src/components/group_users.jsx
+++ b/client/src/components/group_users.jsx
@@ -1,4 +1,5 @@
 import { React, useState, createRef } from "react";
+import { apiPath } from "../api";
 import "../styles/group_users.css";
 import User from "./user";
 import AddUser from "./add_user";
@@ -20,9 +21,6 @@ function GroupUsers(props) {
 
   // Ref to user select for settling
   let userSelectRef = createRef();
-
-  // Server URL
-  const apiUrl = "http://localhost:3001";
 
   // Returns styles to grey out button
   function disabledBtnStyles() {
@@ -50,7 +48,7 @@ function GroupUsers(props) {
     setSettleAmount("");
 
     // Call endpoint
-    let settleDebtResponse = await fetch(`${apiUrl}/debts/settle`, {
+    let settleDebtResponse = await fetch(apiPath("/debts/settle"), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/client/src/testing/app.test.js
+++ b/client/src/testing/app.test.js
@@ -1,8 +1,77 @@
-import { render, screen } from "@testing-library/react";
-import App from "../components/App";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "../components/app";
 
-test("renders FairSplit title", () => {
+function mockJsonResponse(body, options = {}) {
+  return Promise.resolve({
+    ok: options.ok ?? true,
+    json: () => Promise.resolve(body),
+  });
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn((url, options) => {
+    if (options?.method === "POST" && url === "/users") {
+      const body = JSON.parse(options.body);
+      return mockJsonResponse({
+        username: body.username,
+        firstName: body.firstName,
+        lastName: body.lastName,
+      });
+    }
+
+    if (url === "/users") {
+      return mockJsonResponse([]);
+    }
+
+    if (url === "/debts" || url === "/expenses") {
+      return mockJsonResponse([]);
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test("renders FairSplit title", async () => {
   render(<App />);
   const titleElement = screen.getByText(/FairSplit/i);
   expect(titleElement).toBeInTheDocument();
+  await waitFor(() => {
+    expect(fetch).toHaveBeenCalledWith("/users");
+  });
+});
+
+test("renders first-user flow for an empty database", async () => {
+  render(<App />);
+
+  expect(
+    await screen.findByRole("button", { name: /add user/i }),
+  ).toBeVisible();
+  expect(screen.getByText(/Group Members/i)).toBeInTheDocument();
+  expect(screen.queryByText(/You owe/i)).not.toBeInTheDocument();
+});
+
+test("makes the first added user active", async () => {
+  const user = userEvent.setup();
+  render(<App />);
+
+  await user.click(await screen.findByRole("button", { name: /add user/i }));
+  await user.type(screen.getByRole("textbox"), "alice");
+  await user.click(screen.getByRole("button", { name: /add user/i }));
+
+  await waitFor(() => {
+    expect(fetch).toHaveBeenCalledWith(
+      "/users",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+  });
+  await waitFor(() => {
+    expect(screen.getAllByDisplayValue("alice").length).toBeGreaterThan(0);
+  });
 });

--- a/server/routes/users.test.js
+++ b/server/routes/users.test.js
@@ -17,6 +17,9 @@ describe("Test for user routes", () => {
     connection = await mongoose.connect(globalThis.__MONGO_URI__, {
       dbName: "fairsplit-users-test",
     });
+    // Ensure unique indexes exist before duplicate-key assertions run.
+    await userModel.init();
+    await userDebtModel.init();
   });
 
   afterAll(async () => {


### PR DESCRIPTION
# Summary
- Added an empty-group client path
  - Kept the initial screen usable when `/users` returned no records
  - Made the first created user become the active user
- Centralised client API routing
  - Replaced hardcoded client-side localhost calls with relative API paths
  - Kept `REACT_APP_API_URL` available for non-proxy deployments
- Expanded frontend regression coverage
  - Covered empty database loading and first-user creation with mocked API calls
  - Fixed the case-sensitive component import that would fail on Linux
- Added client verification to CI
  - Ran the client test suite and production build alongside the existing backend job
  - Synchronised `client/package-lock.json` so npm 10 can use `npm ci`
- Stabilised the backend duplicate-user test
  - Waited for Mongoose user indexes before asserting duplicate-key rejection

## Rationale
- The app previously assumed a populated user collection
  - A fresh database followed the README setup path into `users[0].username`, crashing before anyone could create the first user
- Relative API paths match the existing CRA proxy setup
  - This removed the `localhost:3000` / `localhost:3001` split without committing the project to one deployment host
- Mongoose `unique` constraints are index-backed
  - The duplicate-user regression test could run before the in-memory Mongo indexes were ready, making CI nondeterministic
