### PR TITLE
chore(config): Harden runtime config and audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ MONGODB_URI="<uri>"
 ```
 
 4. Save the file.
+5. Optional: add `CORS_ORIGIN="<origin>"` if the client is not served from
+   `http://localhost:3000`.
 
 ### Running the Server
 
@@ -55,7 +57,7 @@ MONGODB_URI="<uri>"
 2. Ensure that you're in the root directory: `fairsplit`
 3. Navigate to the server directory: `cd server`
 4. Install dependencies: `npm install`
-5. Run the server: `node app`
+5. Run the server: `npm start`
 
 ### Running the Client
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4105,15 +4105,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -13670,9 +13661,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -14191,9 +14182,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -14327,9 +14318,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -14346,7 +14337,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -15531,6 +15522,15 @@
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
       "license": "CC0-1.0"
     },
+    "node_modules/postcss-svgo/node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/postcss-svgo/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -15541,17 +15541,17 @@
       }
     },
     "node_modules/postcss-svgo/node_modules/svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
+      "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
       "license": "MIT",
       "dependencies": {
-        "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
         "picocolors": "^1.0.0",
+        "sax": "^1.5.0",
         "stable": "^0.1.8"
       },
       "bin": {
@@ -17991,15 +17991,14 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -18013,10 +18012,37 @@
         "webpack": "^5.1.0"
       },
       "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
         "@swc/core": {
           "optional": true
         },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
         "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
           "optional": true
         },
         "uglify-js": {
@@ -18815,9 +18841,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -19492,9 +19518,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"

--- a/server/app.js
+++ b/server/app.js
@@ -1,46 +1,23 @@
 const express = require("express");
-const mongoose = require("mongoose");
-require("dotenv").config();
 const cors = require("cors");
 const usersRouter = require("./routes/users.js");
 const expensesRouter = require("./routes/expenses.js");
 const debtsRouter = require("./routes/debts.js");
 const { errorHandler } = require("./middleware/errors");
 
-const app = express();
-app.use(express.json());
-app.use(
-  cors({
-    origin: "http://localhost:3000",
-  }),
-);
-app.use(usersRouter);
-app.use(expensesRouter);
-app.use(debtsRouter);
-app.use(errorHandler);
+function createApp({ corsOrigin = "http://localhost:3000" } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    cors({
+      origin: corsOrigin,
+    }),
+  );
+  app.use(usersRouter);
+  app.use(expensesRouter);
+  app.use(debtsRouter);
+  app.use(errorHandler);
+  return app;
+}
 
-// !IMPORTANT: Create .env file with password
-const password = process.env.PASSWORD || "changePasswordHere";
-let devUrl = `mongodb+srv://admin:${password}@fairsplit.fjvgxmg.mongodb.net/?retryWrites=true&w=majority`;
-const mongoDB = process.env.MONGODB_URI || devUrl;
-// Set up the Mongoose connection.
-mongoose
-  .connect(mongoDB)
-  .catch((error) => console.error("MongoDB connection error:", error));
-let db = mongoose.connection;
-
-// Bind the connection to an error event to get notification of connection
-// errors.
-db.on("error", console.error.bind(console, "MongoDB connection error:"));
-// Displays a success message when the connection is successfully made.
-db.once("open", function () {
-  console.log("Connected successfully.");
-});
-
-// Set up the port to listen on.
-const port = process.env.PORT || 3001;
-app.listen(port, () => {
-  console.log(`Server is running at port ${port}.`);
-});
-
-module.exports = app;
+module.exports = { createApp };

--- a/server/config.js
+++ b/server/config.js
@@ -1,0 +1,21 @@
+function parsePort(port) {
+  const parsedPort = Number(port);
+  if (!Number.isInteger(parsedPort) || parsedPort < 1) {
+    throw new Error("PORT must be a positive integer.");
+  }
+  return parsedPort;
+}
+
+function getServerConfig(env = process.env) {
+  if (!env.MONGODB_URI) {
+    throw new Error("MONGODB_URI must be set.");
+  }
+
+  return {
+    corsOrigin: env.CORS_ORIGIN || "http://localhost:3000",
+    mongoDB: env.MONGODB_URI,
+    port: parsePort(env.PORT || "3001"),
+  };
+}
+
+module.exports = { getServerConfig, parsePort };

--- a/server/config.test.js
+++ b/server/config.test.js
@@ -1,0 +1,37 @@
+const { getServerConfig, parsePort } = require("./config");
+
+describe("server config", () => {
+  test("requires MONGODB_URI", () => {
+    expect(() => getServerConfig({})).toThrow(/MONGODB_URI/);
+  });
+
+  test("uses safe local defaults for optional runtime config", () => {
+    expect(
+      getServerConfig({
+        MONGODB_URI: "mongodb://localhost:27017/fairsplit",
+      }),
+    ).toEqual({
+      corsOrigin: "http://localhost:3000",
+      mongoDB: "mongodb://localhost:27017/fairsplit",
+      port: 3001,
+    });
+  });
+
+  test("reads explicit runtime config", () => {
+    expect(
+      getServerConfig({
+        CORS_ORIGIN: "https://example.com",
+        MONGODB_URI: "mongodb://localhost:27017/fairsplit",
+        PORT: "8080",
+      }),
+    ).toEqual({
+      corsOrigin: "https://example.com",
+      mongoDB: "mongodb://localhost:27017/fairsplit",
+      port: 8080,
+    });
+  });
+
+  test.each(["0", "-1", "abc", "3000.5"])("rejects invalid PORT %s", (port) => {
+    expect(() => parsePort(port)).toThrow(/PORT/);
+  });
+});

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1416,9 +1416,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -2,8 +2,9 @@
   "name": "server",
   "version": "1.0.0",
   "description": "",
-  "main": "app.js",
+  "main": "server.js",
   "scripts": {
+    "start": "node server.js",
     "test": "jest --verbose --coverage"
   },
   "keywords": [],

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,33 @@
+const mongoose = require("mongoose");
+require("dotenv").config();
+
+const { createApp } = require("./app");
+const { getServerConfig } = require("./config");
+
+async function startServer() {
+  const config = getServerConfig();
+  const app = createApp({ corsOrigin: config.corsOrigin });
+
+  mongoose.connection.on(
+    "error",
+    console.error.bind(console, "MongoDB connection error:"),
+  );
+  mongoose.connection.once("open", () => {
+    console.log("Connected successfully.");
+  });
+
+  await mongoose.connect(config.mongoDB);
+
+  return app.listen(config.port, () => {
+    console.log(`Server is running at port ${config.port}.`);
+  });
+}
+
+if (require.main === module) {
+  startServer().catch((error) => {
+    console.error("Failed to start server:", error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { startServer };


### PR DESCRIPTION
# Summary
- Hardened server runtime configuration
  - Split Express app creation from Mongo connection and server listening
  - Required `MONGODB_URI` at startup and made `CORS_ORIGIN` configurable
- Added config coverage
  - Covered missing Mongo URI, default local runtime config, explicit config, and invalid ports
- Refreshed safe audit fixes
  - Cleared the remaining server audit finding
  - Reduced client audit findings from 32 to 28 without changing direct dependencies
- Updated server startup docs
  - Switched local startup to `npm start` and documented optional `CORS_ORIGIN`

## Rationale
- The old `PASSWORD` fallback created a plausible Atlas URI with placeholder credentials
  - Broken environments failed late as connection errors instead of failing directly on missing `MONGODB_URI`
- Client audit debt is still mostly blocked behind `react-scripts`
  - This PR only took non-force lockfile fixes; the remaining high findings need a frontend tooling migration rather than `npm audit fix --force`
