### PR TITLE
ci: Align test workflow with Dependabot lockfiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [24.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
@@ -31,12 +31,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [24.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
# Summary
- Aligned backend and client CI with the package-manager semantics used by current Dependabot lockfile updates
- Refreshed test-job action runtimes to supported Node.js 24-native releases

## Rationale
- npm 10 rejected Dependabot's client lockfile after an optional `yaml@2.9.0` peer entry was removed
	- Aligning CI with npm 11 fixes clean installs without maintaining a lockfile entry that future Dependabot updates would remove again